### PR TITLE
Avoid double slash on terminal slash in host

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -30,5 +30,5 @@ if [ -z $project ]; then
 fi
 
 curl -s -H "Authorization: Bearer $token" \
-    "$host/api/0/projects/$organization/$project/releases/" \
+    "${host%/}/api/0/projects/$organization/$project/releases/" \
     | jq "map({ \"ref\": .version }) | reverse" >&3

--- a/assets/in
+++ b/assets/in
@@ -36,7 +36,7 @@ ref=$(jq -r '.version.ref // ""' < $payload)
 # Fetch release
 info=$(mktemp $TMPDIR/sentry-releases-resource-info.XXXXXX)
 curl -s -H "Authorization: Bearer $token" \
-    "$host/api/0/organizations/$organization/releases/$ref/" > $info
+    "${host%/}/api/0/organizations/$organization/releases/$ref/" > $info
 
 # Write it
 created=$(jq -r '.dateCreated // ""' < $info)

--- a/assets/out
+++ b/assets/out
@@ -57,7 +57,7 @@ info=$(mktemp $TMPDIR/sentry-releases-resource-release.XXXXXX)
 curl -s -H "Authorization: Bearer $token" \
     -X POST -H "Content-Type: application/json" \
     -d "{\"version\": $(echo $version | jq -R .)}" \
-    "$host/api/0/projects/$organization/$project/releases/" > $info
+    "${host%/}/api/0/projects/$organization/$project/releases/" > $info
 cat $info | jq .
 
 # Upload files
@@ -70,7 +70,7 @@ if [ ! -z $files ]; then
         echo "Uploading $(basename $filename)"
         curl -s -H "Authorization: Bearer $token" \
             -X POST -F file=@$filename -F name="$url_prefix$(basename $filename)" \
-            "$host/api/0/projects/$organization/$project/releases/$version/files/" | jq .
+            "${host%/}/api/0/projects/$organization/$project/releases/$version/files/" | jq .
         echo
     done
 fi


### PR DESCRIPTION
If the user sets host to https://example.com/, it will result in api
calls against https://example.com//api... which may not be accepted by the sentry installation