### PR TITLE
Remove (and check for) unbound variables

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e
+set -eu
 set -o pipefail
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
 # Read inputs
-payload=$(mktemp $TMPDIR/sentry-releases-resource-request.XXXXXX)
+payload=$(mktemp sentry-releases-resource-request.XXXXXX)
 cat > $payload <&0
 
 # Parse parameters

--- a/assets/in
+++ b/assets/in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 set -o pipefail
 
 exec 3>&1 # make stdout available as fd 3 for the result
@@ -14,7 +14,7 @@ if [ -z "$source" ]; then
 fi
 
 # Read inputs
-payload=$(mktemp $TMPDIR/sentry-releases-resource-request.XXXXXX)
+payload=$(mktemp sentry-releases-resource-request.XXXXXX)
 cat > $payload <&0
 
 # Parse parameters

--- a/assets/out
+++ b/assets/out
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 set -o pipefail
 
 exec 3>&1 # make stdout available as fd 3 for the result
@@ -53,7 +53,7 @@ version=$(cat $source/$version_from)
 
 # Create version
 echo "Creating release"
-info=$(mktemp $TMPDIR/sentry-releases-resource-release.XXXXXX)
+info=$(mktemp sentry-releases-resource-release.XXXXXX)
 curl -s -H "Authorization: Bearer $token" \
     -X POST -H "Content-Type: application/json" \
     -d "{\"version\": $(echo $version | jq -R .)}" \


### PR DESCRIPTION
`$TMPDIR` is actually not set in concourse (at least on a 4.x worker on ubuntu)