### PR TITLE
Fail on http errors with message

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -29,6 +29,6 @@ if [ -z $project ]; then
     exit 1
 fi
 
-curl -s -H "Authorization: Bearer $token" \
+curl -sSf -H "Authorization: Bearer $token" \
     "$host/api/0/projects/$organization/$project/releases/" \
     | jq "map({ \"ref\": .version }) | reverse" >&3

--- a/assets/in
+++ b/assets/in
@@ -35,7 +35,7 @@ ref=$(jq -r '.version.ref // ""' < $payload)
 
 # Fetch release
 info=$(mktemp $TMPDIR/sentry-releases-resource-info.XXXXXX)
-curl -s -H "Authorization: Bearer $token" \
+curl -sSf -H "Authorization: Bearer $token" \
     "$host/api/0/organizations/$organization/releases/$ref/" > $info
 
 # Write it

--- a/assets/out
+++ b/assets/out
@@ -54,7 +54,7 @@ version=$(cat $source/$version_from)
 # Create version
 echo "Creating release"
 info=$(mktemp $TMPDIR/sentry-releases-resource-release.XXXXXX)
-curl -s -H "Authorization: Bearer $token" \
+curl -sSf -H "Authorization: Bearer $token" \
     -X POST -H "Content-Type: application/json" \
     -d "{\"version\": $(echo $version | jq -R .)}" \
     "$host/api/0/projects/$organization/$project/releases/" > $info
@@ -68,7 +68,7 @@ if [ ! -z $files ]; then
     fi
     for filename in $source/$files/*; do
         echo "Uploading $(basename $filename)"
-        curl -s -H "Authorization: Bearer $token" \
+        curl -sSf -H "Authorization: Bearer $token" \
             -X POST -F file=@$filename -F name="$url_prefix$(basename $filename)" \
             "$host/api/0/projects/$organization/$project/releases/$version/files/" | jq .
         echo


### PR DESCRIPTION
Without passing the -S and -f flags, curl will succed also on 40x errors
and the user will get a parsing error in jq instead.
By passing the flags, curl will print a more user-friendly error in most cases